### PR TITLE
add docker instructions

### DIFF
--- a/docs/dataset/goldsky_cli.md
+++ b/docs/dataset/goldsky_cli.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 1
+---
+# Downloading with the Goldsky CLI and Docker
+
+You can always install and use the [Goldsky CLI](https://docs.goldsky.com/#quick-start), but in this document we're going to use a Docker image to let you get up and running without directly installing the Goldsky CLI.
+
+## Syncing Data with Docker and the Goldsky CLI
+
+We're assuming you already have [Docker installed](https://docs.docker.com/get-docker/), and if you do, all you need to do is run the following command in your terminal:
+
+`docker run -v $(pwd):/var/opt/indexed-xyz -it goldsky/indexed.xyz:latest goldsky indexed sync decoded-logs`
+
+If you're using an Apple Silicon system, or see an error like `docker: no matching manifest for linux/arm64/v8 in the manifest list entries.`, then try adding `--platform linux/x86_64` like so:
+
+`docker run --platform linux/x86_64 -v $(pwd):/var/opt/indexed-xyz -it goldsky/indexed.xyz:latest goldsky indexed sync decoded-logs`
+
+This will start the Goldsky CLI, and prompt you for a contract address to start downloading data for. If you're not sure where to start, a lot of the examples use the contract address for the [Bored Ape Yacht Club](https://etherscan.io/address/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d), `0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d`.
+
+Data is downloaded into the `./data` directory for you to use. If you want to get started with querying the data without installing anything more, check out our [DuckDB](/examples/duckdb.md) example.
+

--- a/docs/dataset/goldsky_cli.md
+++ b/docs/dataset/goldsky_cli.md
@@ -19,3 +19,4 @@ This will start the Goldsky CLI, and prompt you for a contract address to start 
 
 Data is downloaded into the `./data` directory for you to use. If you want to get started with querying the data without installing anything more, check out our [DuckDB](/examples/duckdb.md) example.
 
+One benefit of downloading the data this way is that it will pre-filter the downloaded data to include only data for the contract you are interested in. As you will see in the [DuckDB](/examples/duckdb.md) example, we're often filtering for a specific `address` because other download methods will download more data than just a single contract, so the filter is necessary.

--- a/docs/dataset/goldsky_cli.md
+++ b/docs/dataset/goldsky_cli.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 ---
+
 # Downloading with the Goldsky CLI and Docker
 
 You can always install and use the [Goldsky CLI](https://docs.goldsky.com/#quick-start), but in this document we're going to use a Docker image to let you get up and running without directly installing the Goldsky CLI.

--- a/docs/examples/duckdb.md
+++ b/docs/examples/duckdb.md
@@ -8,6 +8,12 @@ title: DuckDB + YouPlot
 
 Make sure you install DuckDB first by following their guide [here](https://duckdb.org/#quickinstall). If you're on macOS, we recommend using [Homebrew](https://docs.brew.sh/Installation), you can install duckdb with the following terminal command: `brew install duckdb`
 
+Alternatively, you can run duckdb directly from a docker image we've published like so:
+
+`docker run -v $(pwd):/var/opt/indexed-xyz -it goldsky/indexed.xyz:latest duckdb`
+
+If you followed the steps in the [Goldsky CLI and Docker](/dataset/goldsky_cli.md) guide to download files, keep in mind your data will live in the `./data` directory.
+
 ## Download Parquet Files
 
 You can download the files with the [Goldsky CLI](https://docs.goldsky.com), or by following one of our guides for [AWS CLI](/dataset/awscli.md), or [rclone](/dataset/rclone.md).

--- a/docs/examples/duckdb.md
+++ b/docs/examples/duckdb.md
@@ -10,7 +10,7 @@ Make sure you install DuckDB first by following their guide [here](https://duckd
 
 ## Download Parquet Files
 
-You can download the files with the [Goldsky CLI](https://docs.goldsky.com), or by following one of our guides for [AWS CLI](../dataset/awscli.md), or [rclone](../dataset/rclone.md).
+You can download the files with the [Goldsky CLI](https://docs.goldsky.com), or by following one of our guides for [AWS CLI](/dataset/awscli.md), or [rclone](/dataset/rclone.md).
 
 The prefix we're using is `9d`.
 
@@ -20,7 +20,9 @@ Depending on how you downloaded the files, they may be in a flat directory, or s
 select date_trunc('month', to_timestamp(block_time)), count(*) from '*/*.parquet' where lower(address) = '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d' and event_signature = 'Transfer(address,address,uint256)' group by 1;
 ```
 
-Our files are not in a directory so we'll be using a slightly different query in this example.
+The above query will also work if you used the [Goldsky CLI and Docker](/dataset/goldsky_cli.md), as it puts the data into a `./data` directory which will also match the right path.
+
+Our files are not in a directory, so we'll be using a slightly different query in this example.
 
 ## Counting the Tokens
 


### PR DESCRIPTION
I was going to create a separate docker+duckdb example, but instead tried my best to integrate the workflow of using the CLI into the existing example.